### PR TITLE
Update the documentation for Discus Integration

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -360,6 +360,9 @@ extra:
 A new entry at the bottom of the table of contents is generated that is linking
 to the comments section. The necessary JavaScript is automatically included.
 
+!!! warning
+    `site_url` value must be set in `mkdocs.yml` for the Discus integration to load properly.
+
   [17]: https://disqus.com
 
 ### Localization


### PR DESCRIPTION
'site_url' field is mandatory in the 'mkdocs.yml' file for the Disqus Integration to work, else it will display the error message as "We were unable to load Disqus. If you are a moderator please see our troubleshooting guide."